### PR TITLE
use pkg-config in example/Makefile to link against library

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -5,10 +5,10 @@
 #   CFLAGS : Specify compiler options to use
 
 # Required compiler parameters
-CFLAGS += -I..
+CFLAGS += `pkg-config --cflags mseed`
 
-LDFLAGS = -L..
-LDLIBS = -lmseed
+LDFLAGS = `pkg-config --libs-only-L mseed`
+LDLIBS = `pkg-config --libs-only-l mseed`
 
 all: msview msrepack
 


### PR DESCRIPTION
Now, that we have a .pc file for pkg-config, we can use it in the example/Makefile
