### PR TITLE
Add missing global variables to linker table.

### DIFF
--- a/libmseed.map
+++ b/libmseed.map
@@ -4,7 +4,12 @@
       msr_*;
       mst_*;
       mstl_*;
+      packheaderbyteorder;
+      packdatabyteorder;
+      unpackheaderbyteorder;
+      unpackdatabyteorder;
       unpackencodingformat;
+      unpackencodingfallback;
 
   local:
       *;


### PR DESCRIPTION
These are all used in `MS_*` macros.