### PR TITLE
Don't alias pointers, correctly free on errors, fix memory leak

### DIFF
--- a/msrutils.c
+++ b/msrutils.c
@@ -388,6 +388,12 @@ msr_duplicate (MSRecord *msr, flag datadup)
   /* Copy MSRecord structure */
   memcpy (dupmsr, msr, sizeof (MSRecord));
 
+  /* Reset pointers to not alias memory held by other structures */
+  dupmsr->fsdh = NULL;
+  dupmsr->blkts = NULL;
+  dupmsr->datasamples = NULL;
+  dupmsr->ststate = NULL;
+
   /* Copy fixed-section data header structure */
   if (msr->fsdh)
   {
@@ -395,7 +401,7 @@ msr_duplicate (MSRecord *msr, flag datadup)
     if ((dupmsr->fsdh = (struct fsdh_s *)malloc (sizeof (struct fsdh_s))) == NULL)
     {
       ms_log (2, "msr_duplicate(): Error allocating memory\n");
-      free (dupmsr);
+      msr_free (&dupmsr);
       return NULL;
     }
 
@@ -437,7 +443,7 @@ msr_duplicate (MSRecord *msr, flag datadup)
     {
       ms_log (2, "msr_duplicate(): unrecognized sample type: '%c'\n",
               msr->sampletype);
-      free (dupmsr);
+      msr_free (&dupmsr);
       return NULL;
     }
 
@@ -445,7 +451,7 @@ msr_duplicate (MSRecord *msr, flag datadup)
     if ((dupmsr->datasamples = (void *)malloc ((size_t) (msr->numsamples * samplesize))) == NULL)
     {
       ms_log (2, "msr_duplicate(): Error allocating memory\n");
-      free (dupmsr);
+      msr_free (&dupmsr);
       return NULL;
     }
 


### PR DESCRIPTION
- Modify how an MSRecord structure is freed when there is an invalid sampletype, to avoid a memory leak. This memory leak occurs if the original MSRecord has an invalid sampletype, so that ms_samplesize returns 0, then msr_duplicate leaks memory because the duplicated MSRecord is freed using `free` and not `msr_free`.

- Set pointers to NULL immediately after copying the MSRecord structure, to avoid problems with pointers in the original MSRecord structure and the duplicate pointing to the same memory. These problems occur if there are problems allocating memory, for example if the fsdh field cannot be allocated, then freeing the duplicated MSRecord also frees fields in the original MSRecord. Because msr_duplicate uses memcpy to make the initial copy of the MSRecord, the pointers in the duplicated MSRecord point to the same memory as the original MSRecord. This can cause undefined behavior because it can lead to the same memory being freed twice.