### PR TITLE
Update numsamples and samplecnt consistently

### DIFF
--- a/traceutils.c
+++ b/traceutils.c
@@ -438,7 +438,7 @@ mst_addmsr (MSTrace *mst, MSRecord *msr, flag whence)
 {
   int samplesize = 0;
 
-  if (!mst || !msr)
+  if (!mst || !msr || (whence != 1 && whence != 2))
     return -1;
 
   /* Reallocate data sample buffer if samples are present */
@@ -549,7 +549,7 @@ mst_addspan (MSTrace *mst, hptime_t starttime, hptime_t endtime,
 {
   int samplesize = 0;
 
-  if (!mst)
+  if (!mst || (whence != 1 && whence != 2))
     return -1;
 
   if (datasamples && numsamples > 0)

--- a/traceutils.c
+++ b/traceutils.c
@@ -517,7 +517,7 @@ mst_addmsr (MSTrace *mst, MSRecord *msr, flag whence)
       mst->dataquality = 0;
 
     /* Update MSTrace sample count */
-    mst->samplecnt += msr->samplecnt;
+    mst->samplecnt += msr->numsamples;
   }
 
   return 0;

--- a/traceutils.c
+++ b/traceutils.c
@@ -473,40 +473,34 @@ mst_addmsr (MSTrace *mst, MSRecord *msr, flag whence)
       ms_log (2, "mst_addmsr(): Cannot allocate memory\n");
       return -1;
     }
-  }
 
-  /* Add samples at end of trace */
-  if (whence == 1)
-  {
-    if (msr->datasamples && msr->numsamples >= 0)
+    /* Add samples at end of trace */
+    if (whence == 1)
     {
       memcpy ((char *)mst->datasamples + (mst->numsamples * samplesize),
               msr->datasamples,
               (size_t) (msr->numsamples * samplesize));
 
       mst->numsamples += msr->numsamples;
+
+      mst->endtime = msr_endtime (msr);
+
+      if (mst->endtime == HPTERROR)
+      {
+        ms_log (2, "mst_addmsr(): Error calculating record end time\n");
+        return -1;
+      }
     }
 
-    mst->endtime = msr_endtime (msr);
-
-    if (mst->endtime == HPTERROR)
-    {
-      ms_log (2, "mst_addmsr(): Error calculating record end time\n");
-      return -1;
-    }
-  }
-
-  /* Add samples at the beginning of trace */
-  else if (whence == 2)
-  {
-    if (msr->datasamples && msr->numsamples >= 0)
+    /* Add samples at the beginning of trace */
+    else if (whence == 2)
     {
       /* Move any samples to end of buffer */
       if (mst->numsamples > 0)
       {
         memmove ((char *)mst->datasamples + (msr->numsamples * samplesize),
-                 mst->datasamples,
-                 (size_t) (mst->numsamples * samplesize));
+                  mst->datasamples,
+                  (size_t) (mst->numsamples * samplesize));
       }
 
       memcpy (mst->datasamples,
@@ -514,17 +508,17 @@ mst_addmsr (MSTrace *mst, MSRecord *msr, flag whence)
               (size_t) (msr->numsamples * samplesize));
 
       mst->numsamples += msr->numsamples;
+
+      mst->starttime = msr->starttime;
     }
 
-    mst->starttime = msr->starttime;
+    /* If two different data qualities reset the MSTrace.dataquality to 0 */
+    if (mst->dataquality && msr->dataquality && mst->dataquality != msr->dataquality)
+      mst->dataquality = 0;
+
+    /* Update MSTrace sample count */
+    mst->samplecnt += msr->samplecnt;
   }
-
-  /* If two different data qualities reset the MSTrace.dataquality to 0 */
-  if (mst->dataquality && msr->dataquality && mst->dataquality != msr->dataquality)
-    mst->dataquality = 0;
-
-  /* Update MSTrace sample count */
-  mst->samplecnt += msr->samplecnt;
 
   return 0;
 } /* End of mst_addmsr() */
@@ -576,34 +570,28 @@ mst_addspan (MSTrace *mst, hptime_t starttime, hptime_t endtime,
       ms_log (2, "mst_addspan(): Cannot allocate memory\n");
       return -1;
     }
-  }
 
-  /* Add samples at end of trace */
-  if (whence == 1)
-  {
-    if (datasamples && numsamples > 0)
+    /* Add samples at end of trace */
+    if (whence == 1)
     {
       memcpy ((char *)mst->datasamples + (mst->numsamples * samplesize),
               datasamples,
               (size_t) (numsamples * samplesize));
 
       mst->numsamples += numsamples;
+
+      mst->endtime = endtime;
     }
 
-    mst->endtime = endtime;
-  }
-
-  /* Add samples at the beginning of trace */
-  else if (whence == 2)
-  {
-    if (datasamples && numsamples > 0)
+    /* Add samples at the beginning of trace */
+    else if (whence == 2)
     {
       /* Move any samples to end of buffer */
       if (mst->numsamples > 0)
       {
         memmove ((char *)mst->datasamples + (numsamples * samplesize),
-                 mst->datasamples,
-                 (size_t) (mst->numsamples * samplesize));
+                  mst->datasamples,
+                  (size_t) (mst->numsamples * samplesize));
       }
 
       memcpy (mst->datasamples,
@@ -611,14 +599,15 @@ mst_addspan (MSTrace *mst, hptime_t starttime, hptime_t endtime,
               (size_t) (numsamples * samplesize));
 
       mst->numsamples += numsamples;
+
+      mst->starttime = starttime;
     }
 
-    mst->starttime = starttime;
-  }
+    /* Update MSTrace sample count */
+    if (numsamples > 0)
+      mst->samplecnt += numsamples;
 
-  /* Update MSTrace sample count */
-  if (numsamples > 0)
-    mst->samplecnt += numsamples;
+  }
 
   return 0;
 } /* End of mst_addspan() */


### PR DESCRIPTION
Check that whence argument to mst_addspan and mst_addmsr is valid, which prevents modifications to MSTrace.numsmaples when the number of samples has not actually changed.
    
In mst_addmsr and msr_addspan, update the MSTrace.dataquality and MSTrace.samplecnt only when the source data buffer, which is either MSRecord.datasample or a pointer to a datasamples buffer, is non-null and has data samples.