### PR TITLE
Don't free record data as it does not belong to the record

### DIFF
--- a/tracelist.c
+++ b/tracelist.c
@@ -1197,6 +1197,8 @@ mstl3_pack (MS3TraceList *mstl, void (*record_handler) (char *, int, void *),
     id = id->next;
   }
 
+  /* The record structure never owns the actual data so it should not free it. */
+  msr->datasamples = NULL;
   msr3_free (&msr);
 
   if (packedsamples)


### PR DESCRIPTION
This fixed what I think is a bug in `mstl3_pack()`. The record struct here only receives a pointer to the data and thus should not free it. There is no test for this particular function in the library but in the Python wrapper's I'm working on it works with this change.

There are actually more questions/wishes I have regarding this function:

* This function frees memory from the passed in structs. From a design and practical standpoint I think it should not do this as it did not allocate the memory. A consequence is that when calling this function from any language with some automatic memory management one has to jump through a lot of hoops to not double free it and (at least in my solution) it resulted in an unnecessary copy of the data array. I think this function could and should only work with pointer arithmetic and not free and memory it did not allocate.

* Why is this necessary?

https://github.com/iris-edu/libmseed/blob/41954476b1973cb1bbe8185252cb410703af3079/tracelist.c#L1160-L1161

* I don't think compilers can optimize this and it results in a lot of unnecessary copies (at least one per record). Could be completely avoided by pointer arithmetic.

https://github.com/iris-edu/libmseed/blob/41954476b1973cb1bbe8185252cb410703af3079/tracelist.c#L1168-L1172

I'd be happy to rewrite it with pointer arithmetics but I wondered whether or not there is a deeper reason behind the way it is implemented right now. And are there any additional tests for this functionality?