### PR TITLE
A selection without time windows can also be valid

### DIFF
--- a/selection.c
+++ b/selection.c
@@ -77,11 +77,16 @@ ms3_matchselect (MS3Selections *selections, char *sid, nstime_t starttime,
           continue;
         }
 
-        /* It already passed the sidpattern glob test and the pubversion test. */
-        /* If no time windows are given, the selection matches. */
+        /* If no time selection, this is a match */
         if (!findsl->timewindows)
-          return findsl;
+        {
+          if (ppselecttime)
+            *ppselecttime = NULL;
 
+          return findsl;
+        }
+
+        /* Otherwise, search the time selections */
         findst = findsl->timewindows;
         while (findst)
         {

--- a/selection.c
+++ b/selection.c
@@ -77,6 +77,11 @@ ms3_matchselect (MS3Selections *selections, char *sid, nstime_t starttime,
           continue;
         }
 
+        /* It already passed the sidpattern glob test and the pubversion test. */
+        /* If no time windows are given, the selection matches. */
+        if (!findsl->timewindows)
+          return findsl;
+
         findst = findsl->timewindows;
         while (findst)
         {


### PR DESCRIPTION
With this PR selections without time windows are also valid. I think it should be like this as it is a fairly common case to only select by SID.

A side not: The documentation does not clearly state how multiple given selections are combined. Judging from the code they are combined with `or`, e.g. as soon a single selection matches a record, that record will be read. I agree with this choice but it should be documented.