### PR TITLE
Fix publication version filtering

### DIFF
--- a/selection.c
+++ b/selection.c
@@ -71,7 +71,7 @@ ms3_matchselect (MS3Selections *selections, char *sid, nstime_t starttime,
     {
       if (ms_globmatch (sid, findsl->sidpattern))
       {
-        if (findsl->pubversion > 0 && findsl->pubversion == pubversion)
+        if (findsl->pubversion > 0 && findsl->pubversion != pubversion)
         {
           findsl = findsl->next;
           continue;


### PR DESCRIPTION
I assume the filtering is indented to work in a positive way, e.g. retain records with the given publication version.