### PR TITLE
Check for null argument to msr3_sampratehz

### DIFF
--- a/msrutils.c
+++ b/msrutils.c
@@ -296,6 +296,9 @@ msr3_print (MS3Record *msr, int8_t details)
 inline double
 msr3_sampratehz (MS3Record *msr)
 {
+  if (!msr)
+    return 0.0;
+
   if (msr->samprate < 0.0)
     return (-1.0 / msr->samprate);
   else


### PR DESCRIPTION
The argument to msr3_sampratehz is not checked if it is null, leading to a possible null pointer dereference.