### PR TITLE
always set pubversion to 0 when calling ms3_readtracelist_timewin()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,8 @@ install: shared
 	     mseed.pc.in > $(DESTDIR)$(LIBDIR)/pkgconfig/mseed.pc
 	@mkdir -p $(DESTDIR)$(DOCDIR)/example
 	@cp -r example $(DESTDIR)$(DOCDIR)/
+	ln -s $(LIB_SO) $(LIB_SO_BASE)
+	ln -s $(LIB_SO) $(LIB_SO_MAJOR)
 
 .SUFFIXES: .c .o .lo
 

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,8 @@ $(LIB_SO): $(LIB_LOBJS)
 	@echo "Building shared library $(LIB_SO)"
 	$(RM) -f $(LIB_SO) $(LIB_SO_MAJOR) $(LIB_SO_BASE)
 	$(CC) $(CFLAGS) $(LDFLAGS) $(LIB_OPTS) -o $(LIB_SO) $(LIB_LOBJS)
+	ln -s $(LIB_SO) $(LIB_SO_BASE)
+	ln -s $(LIB_SO) $(LIB_SO_MAJOR)
 
 test check: static FORCE
 	@$(MAKE) -C test test
@@ -86,8 +88,6 @@ install: shared
 	     mseed.pc.in > $(DESTDIR)$(LIBDIR)/pkgconfig/mseed.pc
 	@mkdir -p $(DESTDIR)$(DOCDIR)/example
 	@cp -r example $(DESTDIR)$(DOCDIR)/
-	ln -s $(LIB_SO) $(LIB_SO_BASE)
-	ln -s $(LIB_SO) $(LIB_SO_MAJOR)
 
 .SUFFIXES: .c .o .lo
 

--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,6 @@ $(LIB_SO): $(LIB_LOBJS)
 	@echo "Building shared library $(LIB_SO)"
 	$(RM) -f $(LIB_SO) $(LIB_SO_MAJOR) $(LIB_SO_BASE)
 	$(CC) $(CFLAGS) $(LDFLAGS) $(LIB_OPTS) -o $(LIB_SO) $(LIB_LOBJS)
-	ln -s $(LIB_SO) $(LIB_SO_BASE)
-	ln -s $(LIB_SO) $(LIB_SO_MAJOR)
 
 test check: static FORCE
 	@$(MAKE) -C test test

--- a/example/lm_read_timewin.c
+++ b/example/lm_read_timewin.c
@@ -1,0 +1,97 @@
+/***************************************************************************
+ * A program for reading miniSEED using ms3_readtracelist_timewin() to limit
+ * which data is read according to their timestamp. This program also shows
+ * how to traverse a trace list.
+ *
+ * This file is adapted from lm_read_selection.c.
+ *
+ * Usage: ./lm_read_timewin <mseedfile> <start> <endtime>
+ * For example, ./lm_read_timewin test.mseed 2010,058,06,00,00 2010,058,07,00,00
+ ***************************************************************************/
+
+#include <stdio.h>
+#include <sys/stat.h>
+#include <error.h>
+
+#include <libmseed.h>
+
+int main(int argc, char **argv)
+{
+  MS3TraceList *mstl = NULL;
+  MS3TraceID *tid = NULL;
+  MS3TraceSeg *seg = NULL;
+
+  char *mseedfile = NULL;
+  nstime_t starttime;
+  nstime_t endtime;
+  char starttimestr[30];
+  char endtimestr[30];
+  uint32_t flags = 0;
+  int8_t verbose = 0;
+  int rv;
+
+  /* Parse input parameters */
+  if(argc != 4)
+  {
+    ms_log(2, "Usage: %s <mseedfile> <starttime> <endtime>\n", argv[0]);
+    return -1;
+  }
+  mseedfile = argv[1];
+  starttime = ms_timestr2nstime(argv[2]);
+  endtime = ms_timestr2nstime(argv[3]);
+
+  /* Set bit flags to validate CRC and unpack data samples */
+  flags |= MSF_VALIDATECRC;
+  flags |= MSF_UNPACKDATA;
+
+  /* Read all miniSEED into a trace list, limiting from start time to end
+   * end time */
+  rv = ms3_readtracelist_timewin(&mstl, mseedfile, NULL,
+    starttime, endtime,
+    0, flags, verbose);
+  if(rv != MS_NOERROR)
+  {
+    ms_log (2, "Cannot read miniSEED from file: %s\n", ms_errorstr(rv));
+    return -1;
+  }
+
+  /* Traverse trace list structures and print summary information */
+  tid = mstl->traces;
+  while(tid)
+  {
+    if (!ms_nstime2timestr (tid->earliest, starttimestr, SEEDORDINAL, NANO_MICRO_NONE) ||
+        !ms_nstime2timestr (tid->latest, endtimestr, SEEDORDINAL, NANO_MICRO_NONE))
+    {
+      ms_log (2, "Cannot create time strings\n");
+      starttimestr[0] = endtimestr[0] = '\0';
+    }
+
+    ms_log (0, "TraceID for %s (%d), earliest: %s, latest: %s, segments: %u\n",
+            tid->sid, tid->pubversion, starttimestr, endtimestr, tid->numsegments);
+
+    seg = tid->first;
+    while (seg)
+    {
+      if (!ms_nstime2timestr (seg->starttime, starttimestr, SEEDORDINAL, NANO_MICRO_NONE) ||
+          !ms_nstime2timestr (seg->endtime, endtimestr, SEEDORDINAL, NANO_MICRO_NONE))
+      {
+        ms_log (2, "Cannot create time strings\n");
+        starttimestr[0] = endtimestr[0] = '\0';
+      }
+
+      ms_log (0, "  Segment %s - %s, samples: %" PRId64 ", sample rate: %g, sample type: %c\n",
+              starttimestr, endtimestr, seg->numsamples, seg->samprate,
+              (seg->sampletype) ? seg->sampletype : ' ');
+
+      seg = seg->next;
+    }
+
+    tid = tid->next;
+  }
+
+  /* Make sure everything is cleaned up */
+  if (mstl)
+    mstl3_free (&mstl, 0);
+
+  return 0;
+}

--- a/fileutils.c
+++ b/fileutils.c
@@ -605,6 +605,7 @@ ms3_readtracelist_timewin (MS3TraceList **ppmstl, const char *msfile,
   selection.sidpattern[1] = '\0';
   selection.timewindows   = &selecttime;
   selection.next          = NULL;
+  selection.pubversion = 0;
 
   selecttime.starttime = starttime;
   selecttime.endtime   = endtime;


### PR DESCRIPTION
Set the `pubversion` to 0 when calling `ms3_readtracelist_timewin()` to solve the problem mentioned in issue #65 .