### PR TITLE
Simplify byte swapping routines (v2)

### DIFF
--- a/doc/ms_gswap.3
+++ b/doc/ms_gswap.3
@@ -23,13 +23,11 @@ ms_gswap - Generalized, in-place byte swapping routines
 
 .SH DESCRIPTION
 These routines swap between LSBF (little-endian) and MSBF (big-endian)
-byte orders.  The specified quantities are swapped in-place.  There
-are two versions of most routines: a generic one that works on
-quantities regardless of memory alignment (ms_gswap#) and one that works
-on memory aligned quantities (ms_gswap#a).  The versions for memory
-aligned quantities are much faster than their generic versions, but
-the memory *must* be aligned.  You have been warned. There is only a
-generic version for 3-byte quantities.
+byte orders.  The specified quantities are swapped in-place.
+
+The \fBms_gswap*a\fP routines are provided for backwards compatibility, but
+should not be used in new code. They are aliases for the regular versions
+above.
 
 .SH AUTHOR
 .nf

--- a/gswap.c
+++ b/gswap.c
@@ -6,14 +6,12 @@
  *
  * Some standard integer types are needed, namely uint8_t and
  * uint32_t, (these are normally declared by including inttypes.h or
- * stdint.h).  Each function expects it's input to be a void pointer
+ * stdint.h).  Each function expects its input to be a void pointer
  * to a quantity of the appropriate size.
  *
- * There are two versions of most routines, one that works on
- * quantities regardless of alignment (gswapX) and one that works on
- * memory aligned quantities (gswapXa).  The memory aligned versions
- * (gswapXa) are much faster than the other versions (gswapX), but the
- * memory *must* be aligned.
+ * There are two versions of most routines.  The memory aligned versions
+ * (gswapXa) are aliases of the other versions (gswapX) provided for backwards
+ * compatibility.  There is no difference between them.
  *
  * Written by Chad Trabant,
  *   IRIS Data Management Center
@@ -28,115 +26,73 @@
 void
 ms_gswap2 (void *data2)
 {
-  uint8_t temp;
-
-  union {
-    uint8_t c[2];
-  } dat;
+  uint16_t dat;
 
   memcpy (&dat, data2, 2);
-  temp     = dat.c[0];
-  dat.c[0] = dat.c[1];
-  dat.c[1] = temp;
+
+  dat = ((dat & 0xff00) >> 8) | ((dat & 0x00ff) << 8);
+
   memcpy (data2, &dat, 2);
 }
 
 void
 ms_gswap3 (void *data3)
 {
+  uint8_t dat[3];
   uint8_t temp;
 
-  union {
-    uint8_t c[3];
-  } dat;
-
   memcpy (&dat, data3, 3);
-  temp     = dat.c[0];
-  dat.c[0] = dat.c[2];
-  dat.c[2] = temp;
+  temp   = dat[0];
+  dat[0] = dat[2];
+  dat[2] = temp;
   memcpy (data3, &dat, 3);
 }
 
 void
 ms_gswap4 (void *data4)
 {
-  uint8_t temp;
-
-  union {
-    uint8_t c[4];
-  } dat;
+  uint32_t dat;
 
   memcpy (&dat, data4, 4);
-  temp     = dat.c[0];
-  dat.c[0] = dat.c[3];
-  dat.c[3] = temp;
-  temp     = dat.c[1];
-  dat.c[1] = dat.c[2];
-  dat.c[2] = temp;
+
+  dat = ((dat & 0xff000000) >> 24) | ((dat & 0x000000ff) << 24) |
+        ((dat & 0x00ff0000) >>  8) | ((dat & 0x0000ff00) <<  8);
+
   memcpy (data4, &dat, 4);
 }
 
 void
 ms_gswap8 (void *data8)
 {
-  uint8_t temp;
+  uint64_t dat;
 
-  union {
-    uint8_t c[8];
-  } dat;
+  memcpy (&dat, data8, sizeof(uint64_t));
 
-  memcpy (&dat, data8, 8);
-  temp     = dat.c[0];
-  dat.c[0] = dat.c[7];
-  dat.c[7] = temp;
+  dat = ((dat & 0xff00000000000000) >> 56) | ((dat & 0x00000000000000ff) << 56) |
+        ((dat & 0x00ff000000000000) >> 40) | ((dat & 0x000000000000ff00) << 40) |
+        ((dat & 0x0000ff0000000000) >> 24) | ((dat & 0x0000000000ff0000) << 24) |
+        ((dat & 0x000000ff00000000) >>  8) | ((dat & 0x00000000ff000000) <<  8);
 
-  temp     = dat.c[1];
-  dat.c[1] = dat.c[6];
-  dat.c[6] = temp;
-
-  temp     = dat.c[2];
-  dat.c[2] = dat.c[5];
-  dat.c[5] = temp;
-
-  temp     = dat.c[3];
-  dat.c[3] = dat.c[4];
-  dat.c[4] = temp;
-  memcpy (data8, &dat, 8);
+  memcpy (data8, &dat, sizeof(uint64_t));
 }
 
-/* Swap routines that work on memory aligned quantities */
+/* Swap routines that work on memory aligned quantities are the same as the
+ * generic routines. The symbols below exist for backwards compatibility. */
 
 void
 ms_gswap2a (void *data2)
 {
-  uint16_t *data = data2;
-
-  *data = (((*data >> 8) & 0xff) | ((*data & 0xff) << 8));
+  ms_gswap2 (data2);
 }
 
 void
 ms_gswap4a (void *data4)
 {
-  uint32_t *data = data4;
-
-  *data = (((*data >> 24) & 0xff) | ((*data & 0xff) << 24) |
-           ((*data >> 8) & 0xff00) | ((*data & 0xff00) << 8));
+  ms_gswap4 (data4);
 }
 
 void
 ms_gswap8a (void *data8)
 {
-  uint32_t *data4 = data8;
-  uint32_t h0, h1;
-
-  h0 = data4[0];
-  h0 = (((h0 >> 24) & 0xff) | ((h0 & 0xff) << 24) |
-        ((h0 >> 8) & 0xff00) | ((h0 & 0xff00) << 8));
-
-  h1 = data4[1];
-  h1 = (((h1 >> 24) & 0xff) | ((h1 & 0xff) << 24) |
-        ((h1 >> 8) & 0xff00) | ((h1 & 0xff00) << 8));
-
-  data4[0] = h1;
-  data4[1] = h0;
+  ms_gswap8 (data8);
 }

--- a/libmseed.h
+++ b/libmseed.h
@@ -816,10 +816,27 @@ extern void     ms_gswap3 ( void *data3 );
 extern void     ms_gswap4 ( void *data4 );
 extern void     ms_gswap8 ( void *data8 );
 
-/* Generic byte swapping routines for memory aligned quantities */
+/* Generic byte swapping routines for memory aligned quantities; names exist
+ * for backwards compatibility, but are the same as the generic routines. */
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5) || defined (__clang__)
+__attribute__ ((deprecated("Use ms_gswap2 instead.")))
+extern void     ms_gswap2a ( void *data2 );
+__attribute__ ((deprecated("Use ms_gswap4 instead.")))
+extern void     ms_gswap4a ( void *data4 );
+__attribute__ ((deprecated("Use ms_gswap8 instead.")))
+extern void     ms_gswap8a ( void *data8 );
+#elif defined(_MSC_FULL_VER) && (_MSC_FULL_VER > 140050320)
+__declspec(deprecated("Use ms_gswap2 instead."))
+extern void     ms_gswap2a ( void *data2 );
+__declspec(deprecated("Use ms_gswap4 instead."))
+extern void     ms_gswap4a ( void *data4 );
+__declspec(deprecated("Use ms_gswap8 instead."))
+extern void     ms_gswap8a ( void *data8 );
+#else
 extern void     ms_gswap2a ( void *data2 );
 extern void     ms_gswap4a ( void *data4 );
 extern void     ms_gswap8a ( void *data8 );
+#endif
 
 /* Byte swap macro for the BTime struct */
 #define MS_SWAPBTIME(x) \

--- a/packdata.c
+++ b/packdata.c
@@ -74,7 +74,7 @@ msr_encode_int16 (int32_t *input, int samplecount, int16_t *output,
     output[idx] = (int16_t)input[idx];
 
     if (swapflag)
-      ms_gswap2a (&output[idx]);
+      ms_gswap2 (&output[idx]);
 
     outputlength -= sizeof (int16_t);
   }
@@ -111,7 +111,7 @@ msr_encode_int32 (int32_t *input, int samplecount, int32_t *output,
     output[idx] = input[idx];
 
     if (swapflag)
-      ms_gswap4a (&output[idx]);
+      ms_gswap4 (&output[idx]);
 
     outputlength -= sizeof (int32_t);
   }
@@ -148,7 +148,7 @@ msr_encode_float32 (float *input, int samplecount, float *output,
     output[idx] = input[idx];
 
     if (swapflag)
-      ms_gswap4a (&output[idx]);
+      ms_gswap4 (&output[idx]);
 
     outputlength -= sizeof (float);
   }
@@ -185,7 +185,7 @@ msr_encode_float64 (double *input, int samplecount, double *output,
     output[idx] = input[idx];
 
     if (swapflag)
-      ms_gswap8a (&output[idx]);
+      ms_gswap8 (&output[idx]);
 
     outputlength -= sizeof (double);
   }
@@ -287,7 +287,7 @@ msr_encode_steim1 (int32_t *input, int samplecount, int32_t *output,
         ms_log (1, "Frame %d: X0=%d\n", frameidx, frameptr[1]);
 
       if (swapflag)
-        ms_gswap4a (&frameptr[1]);
+        ms_gswap4 (&frameptr[1]);
 
       Xnp = &frameptr[2];
 
@@ -360,8 +360,8 @@ msr_encode_steim1 (int32_t *input, int samplecount, int32_t *output,
 
         if (swapflag)
         {
-          ms_gswap2a (&word->d16[0]);
-          ms_gswap2a (&word->d16[1]);
+          ms_gswap2 (&word->d16[0]);
+          ms_gswap2 (&word->d16[1]);
         }
 
         /* 2-bit nibble is 0b10 (0x2) */
@@ -378,7 +378,7 @@ msr_encode_steim1 (int32_t *input, int samplecount, int32_t *output,
         frameptr[widx] = diffs[0];
 
         if (swapflag)
-          ms_gswap4a (&frameptr[widx]);
+          ms_gswap4 (&frameptr[widx]);
 
         /* 2-bit nibble is 0b11 (0x3) */
         frameptr[0] |= 0x3ul << (30 - 2 * widx);
@@ -392,14 +392,14 @@ msr_encode_steim1 (int32_t *input, int samplecount, int32_t *output,
 
     /* Swap word with nibbles */
     if (swapflag)
-      ms_gswap4a (&frameptr[0]);
+      ms_gswap4 (&frameptr[0]);
   } /* Done with frames */
 
   /* Set Xn (reverse integration constant) in first frame to last sample */
   if (Xnp)
     *Xnp = *(input + outputsamples - 1);
   if (swapflag)
-    ms_gswap4a (Xnp);
+    ms_gswap4 (Xnp);
 
   /* Pad any remaining bytes */
   if ((frameidx * 64) < outputlength)
@@ -478,7 +478,7 @@ msr_encode_steim2 (int32_t *input, int samplecount, int32_t *output,
         ms_log (1, "Frame %d: X0=%d\n", frameidx, frameptr[1]);
 
       if (swapflag)
-        ms_gswap4a (&frameptr[1]);
+        ms_gswap4 (&frameptr[1]);
 
       Xnp = (int32_t *)&frameptr[2];
 
@@ -687,7 +687,7 @@ msr_encode_steim2 (int32_t *input, int samplecount, int32_t *output,
 
       /* Swap encoded word except for 4x8-bit samples */
       if (swapflag && packedsamples != 4)
-        ms_gswap4a (&frameptr[widx]);
+        ms_gswap4 (&frameptr[widx]);
 
       diffcount -= packedsamples;
       outputsamples += packedsamples;
@@ -695,14 +695,14 @@ msr_encode_steim2 (int32_t *input, int samplecount, int32_t *output,
 
     /* Swap word with nibbles */
     if (swapflag)
-      ms_gswap4a (&frameptr[0]);
+      ms_gswap4 (&frameptr[0]);
   } /* Done with frames */
 
   /* Set Xn (reverse integration constant) in first frame to last sample */
   if (Xnp)
     *Xnp = *(input + outputsamples - 1);
   if (swapflag)
-    ms_gswap4a (Xnp);
+    ms_gswap4 (Xnp);
 
   /* Pad any remaining bytes */
   if ((frameidx * 64) < outputlength)

--- a/parseutils.c
+++ b/parseutils.c
@@ -396,12 +396,12 @@ ms_parse_raw (char *record, int maxreclen, flag details, flag swapflag)
   if (swapflag)
   {
     MS_SWAPBTIME (&fsdh->start_time);
-    ms_gswap2a (&fsdh->numsamples);
-    ms_gswap2a (&fsdh->samprate_fact);
-    ms_gswap2a (&fsdh->samprate_mult);
-    ms_gswap4a (&fsdh->time_correct);
-    ms_gswap2a (&fsdh->data_offset);
-    ms_gswap2a (&fsdh->blockette_offset);
+    ms_gswap2 (&fsdh->numsamples);
+    ms_gswap2 (&fsdh->samprate_fact);
+    ms_gswap2 (&fsdh->samprate_mult);
+    ms_gswap4 (&fsdh->time_correct);
+    ms_gswap2 (&fsdh->data_offset);
+    ms_gswap2 (&fsdh->blockette_offset);
   }
 
   /* Validate fixed section header fields */

--- a/unpack.c
+++ b/unpack.c
@@ -156,12 +156,12 @@ msr_unpack (char *record, int reclen, MSRecord **ppmsr,
   if (headerswapflag)
   {
     MS_SWAPBTIME (&msr->fsdh->start_time);
-    ms_gswap2a (&msr->fsdh->numsamples);
-    ms_gswap2a (&msr->fsdh->samprate_fact);
-    ms_gswap2a (&msr->fsdh->samprate_mult);
-    ms_gswap4a (&msr->fsdh->time_correct);
-    ms_gswap2a (&msr->fsdh->data_offset);
-    ms_gswap2a (&msr->fsdh->blockette_offset);
+    ms_gswap2 (&msr->fsdh->numsamples);
+    ms_gswap2 (&msr->fsdh->samprate_fact);
+    ms_gswap2 (&msr->fsdh->samprate_mult);
+    ms_gswap4 (&msr->fsdh->time_correct);
+    ms_gswap2 (&msr->fsdh->data_offset);
+    ms_gswap2 (&msr->fsdh->blockette_offset);
   }
 
   /* Populate some of the common header fields */

--- a/unpackdata.c
+++ b/unpackdata.c
@@ -50,7 +50,7 @@ msr_decode_int16 (int16_t *input, int samplecount, int32_t *output,
     sample = input[idx];
 
     if (swapflag)
-      ms_gswap2a (&sample);
+      ms_gswap2 (&sample);
 
     output[idx] = (int32_t)sample;
 
@@ -86,7 +86,7 @@ msr_decode_int32 (int32_t *input, int samplecount, int32_t *output,
     sample = input[idx];
 
     if (swapflag)
-      ms_gswap4a (&sample);
+      ms_gswap4 (&sample);
 
     output[idx] = sample;
 
@@ -122,7 +122,7 @@ msr_decode_float32 (float *input, int samplecount, float *output,
     memcpy (&sample, &input[idx], sizeof (float));
 
     if (swapflag)
-      ms_gswap4a (&sample);
+      ms_gswap4 (&sample);
 
     output[idx] = sample;
 
@@ -158,7 +158,7 @@ msr_decode_float64 (double *input, int samplecount, double *output,
     memcpy (&sample, &input[idx], sizeof (double));
 
     if (swapflag)
-      ms_gswap8a (&sample);
+      ms_gswap8 (&sample);
 
     output[idx] = sample;
 
@@ -220,8 +220,8 @@ msr_decode_steim1 (int32_t *input, int inputlength, int samplecount,
     {
       if (swapflag)
       {
-        ms_gswap4a (&frame[1]);
-        ms_gswap4a (&frame[2]);
+        ms_gswap4 (&frame[1]);
+        ms_gswap4 (&frame[2]);
       }
 
       X0 = frame[1];
@@ -242,7 +242,7 @@ msr_decode_steim1 (int32_t *input, int inputlength, int samplecount,
 
     /* Swap 32-bit word containing the nibbles */
     if (swapflag)
-      ms_gswap4a (&frame[0]);
+      ms_gswap4 (&frame[0]);
 
     /* Decode each 32-bit word according to nibble */
     for (widx = startnibble; widx < 16 && samplecount > 0; widx++)
@@ -273,8 +273,8 @@ msr_decode_steim1 (int32_t *input, int inputlength, int samplecount,
 
         if (swapflag)
         {
-          ms_gswap2a (&word->d16[0]);
-          ms_gswap2a (&word->d16[1]);
+          ms_gswap2 (&word->d16[0]);
+          ms_gswap2 (&word->d16[1]);
         }
 
         if (decodedebug)
@@ -284,7 +284,7 @@ msr_decode_steim1 (int32_t *input, int inputlength, int samplecount,
       case 3: /* 11: One 4-byte difference */
         diffcount = 1;
         if (swapflag)
-          ms_gswap4a (&word->d32);
+          ms_gswap4 (&word->d32);
 
         if (decodedebug)
           ms_log (1, "  W%02d: 11=1x32b  %d\n", widx, word->d32);
@@ -375,8 +375,8 @@ msr_decode_steim2 (int32_t *input, int inputlength, int samplecount,
     {
       if (swapflag)
       {
-        ms_gswap4a (&frame[1]);
-        ms_gswap4a (&frame[2]);
+        ms_gswap4 (&frame[1]);
+        ms_gswap4 (&frame[2]);
       }
 
       X0 = frame[1];
@@ -397,7 +397,7 @@ msr_decode_steim2 (int32_t *input, int inputlength, int samplecount,
 
     /* Swap 32-bit word containing the nibbles */
     if (swapflag)
-      ms_gswap4a (&frame[0]);
+      ms_gswap4 (&frame[0]);
 
     /* Decode each 32-bit word according to nibble */
     for (widx = startnibble; widx < 16 && samplecount > 0; widx++)
@@ -428,7 +428,7 @@ msr_decode_steim2 (int32_t *input, int inputlength, int samplecount,
 
       case 2: /* nibble=10: Must consult dnib, the high order two bits */
         if (swapflag)
-          ms_gswap4a (&frame[widx]);
+          ms_gswap4 (&frame[widx]);
         dnib = EXTRACTBITRANGE (frame[widx], 30, 2);
 
         switch (dnib)
@@ -480,7 +480,7 @@ msr_decode_steim2 (int32_t *input, int inputlength, int samplecount,
 
       case 3: /* nibble=11: Must consult dnib, the high order two bits */
         if (swapflag)
-          ms_gswap4a (&frame[widx]);
+          ms_gswap4 (&frame[widx]);
         dnib = EXTRACTBITRANGE (frame[widx], 30, 2);
 
         switch (dnib)
@@ -638,7 +638,7 @@ msr_decode_geoscope (char *input, int samplecount, float *output,
     case DE_GEOSCOPE163:
       memcpy (&sint, input, sizeof (int16_t));
       if (swapflag)
-        ms_gswap2a (&sint);
+        ms_gswap2 (&sint);
 
       /* Recover mantissa and gain range factor */
       mantissa  = (sint & GEOSCOPE_MANTISSA_MASK);
@@ -655,7 +655,7 @@ msr_decode_geoscope (char *input, int samplecount, float *output,
     case DE_GEOSCOPE164:
       memcpy (&sint, input, sizeof (int16_t));
       if (swapflag)
-        ms_gswap2a (&sint);
+        ms_gswap2 (&sint);
 
       /* Recover mantissa and gain range factor */
       mantissa  = (sint & GEOSCOPE_MANTISSA_MASK);
@@ -751,7 +751,7 @@ msr_decode_cdsn (int16_t *input, int samplecount, int32_t *output,
   {
     memcpy (&sint, &input[idx], sizeof (int16_t));
     if (swapflag)
-      ms_gswap2a (&sint);
+      ms_gswap2 (&sint);
 
     /* Recover mantissa and gain range factor */
     mantissa  = (sint & CDSN_MANTISSA_MASK);
@@ -844,7 +844,7 @@ msr_decode_sro (int16_t *input, int samplecount, int32_t *output,
   {
     memcpy (&sint, &input[idx], sizeof (int16_t));
     if (swapflag)
-      ms_gswap2a (&sint);
+      ms_gswap2 (&sint);
 
     /* Recover mantissa and gain range factor */
     mantissa  = (sint & SRO_MANTISSA_MASK);
@@ -898,7 +898,7 @@ msr_decode_dwwssn (int16_t *input, int samplecount, int32_t *output,
   {
     memcpy (&sint, &input[idx], sizeof (uint16_t));
     if (swapflag)
-      ms_gswap2a (&sint);
+      ms_gswap2 (&sint);
     sample = (int32_t)sint;
 
     /* Take 2's complement for sample */


### PR DESCRIPTION
Firstly, compilers are smart enough that the naive copy-and-bit shift method is converted to a register load/store + `bswap` intrinsic. Specialized versions only serve to confuse the reader and end up with the same or worse compiled code.

Secondly, the cast to `uint32_t*` on a `float` array (in `msr_decode_float32` via `ms_gswap4a`) appears to violate strict aliasing rules, such that an optimizing compiler _ignores the byte swap entirely_.