### PR TITLE
Simplify byte swapping routines (v3)

### DIFF
--- a/gswap.c
+++ b/gswap.c
@@ -6,11 +6,9 @@
  * uint32_t.  Each function expects its input to be a void pointer to
  * a quantity of the appropriate size.
  *
- * There are two versions of most routines, one that works on
- * quantities regardless of alignment (gswapX) and one that works on
- * memory aligned quantities (gswapXa).  The memory aligned versions
- * (gswapXa) are much faster than the other versions (gswapX), but the
- * memory *must* be aligned.
+ * There are two versions of most routines.  The memory aligned versions
+ * (gswapXa) are aliases of the other versions (gswapX) provided for backwards
+ * compatibility.  There is no difference between them.
  *
  * This file is part of the miniSEED Library.
  *
@@ -36,99 +34,60 @@
 void
 ms_gswap2 (void *data2)
 {
-  uint8_t temp;
-
-  union {
-    uint8_t c[2];
-  } dat;
+  uint16_t dat;
 
   memcpy (&dat, data2, 2);
-  temp     = dat.c[0];
-  dat.c[0] = dat.c[1];
-  dat.c[1] = temp;
+
+  dat = ((dat & 0xff00) >> 8) | ((dat & 0x00ff) << 8);
+
   memcpy (data2, &dat, 2);
 }
 
 void
 ms_gswap4 (void *data4)
 {
-  uint8_t temp;
-
-  union {
-    uint8_t c[4];
-  } dat;
+  uint32_t dat;
 
   memcpy (&dat, data4, 4);
-  temp     = dat.c[0];
-  dat.c[0] = dat.c[3];
-  dat.c[3] = temp;
-  temp     = dat.c[1];
-  dat.c[1] = dat.c[2];
-  dat.c[2] = temp;
+
+  dat = ((dat & 0xff000000) >> 24) | ((dat & 0x000000ff) << 24) |
+        ((dat & 0x00ff0000) >>  8) | ((dat & 0x0000ff00) <<  8);
+
   memcpy (data4, &dat, 4);
 }
 
 void
 ms_gswap8 (void *data8)
 {
-  uint8_t temp;
+  uint64_t dat;
 
-  union {
-    uint8_t c[8];
-  } dat;
+  memcpy (&dat, data8, sizeof(uint64_t));
 
-  memcpy (&dat, data8, 8);
-  temp     = dat.c[0];
-  dat.c[0] = dat.c[7];
-  dat.c[7] = temp;
+  dat = ((dat & 0xff00000000000000) >> 56) | ((dat & 0x00000000000000ff) << 56) |
+        ((dat & 0x00ff000000000000) >> 40) | ((dat & 0x000000000000ff00) << 40) |
+        ((dat & 0x0000ff0000000000) >> 24) | ((dat & 0x0000000000ff0000) << 24) |
+        ((dat & 0x000000ff00000000) >>  8) | ((dat & 0x00000000ff000000) <<  8);
 
-  temp     = dat.c[1];
-  dat.c[1] = dat.c[6];
-  dat.c[6] = temp;
-
-  temp     = dat.c[2];
-  dat.c[2] = dat.c[5];
-  dat.c[5] = temp;
-
-  temp     = dat.c[3];
-  dat.c[3] = dat.c[4];
-  dat.c[4] = temp;
-  memcpy (data8, &dat, 8);
+  memcpy (data8, &dat, sizeof(uint64_t));
 }
 
-/* Swap routines that work on memory aligned quantities */
+/* Swap routines that work on memory aligned quantities are the same as the
+ * generic routines. The symbols below exist for backwards compatibility. */
 
 void
 ms_gswap2a (void *data2)
 {
-  uint16_t *data = (uint16_t *) data2;
-
-  *data = (((*data >> 8) & 0xff) | ((*data & 0xff) << 8));
+  ms_gswap2 (data2);
 }
 
 void
 ms_gswap4a (void *data4)
 {
-  uint32_t *data = (uint32_t *) data4;
-
-  *data = (((*data >> 24) & 0xff) | ((*data & 0xff) << 24) |
-           ((*data >> 8) & 0xff00) | ((*data & 0xff00) << 8));
+  ms_gswap4 (data4);
 }
 
 void
 ms_gswap8a (void *data8)
 {
-  uint32_t *data4 = (uint32_t *) data8;
-  uint32_t h0, h1;
-
-  h0 = data4[0];
-  h0 = (((h0 >> 24) & 0xff) | ((h0 & 0xff) << 24) |
-        ((h0 >> 8) & 0xff00) | ((h0 & 0xff00) << 8));
-
-  h1 = data4[1];
-  h1 = (((h1 >> 24) & 0xff) | ((h1 & 0xff) << 24) |
-        ((h1 >> 8) & 0xff00) | ((h1 & 0xff00) << 8));
-
-  data4[0] = h1;
-  data4[1] = h0;
+  ms_gswap8 (data8);
 }

--- a/libmseed.h
+++ b/libmseed.h
@@ -1157,12 +1157,34 @@ extern void ms_gswap4 (void *data4);
 /** In-place byte swapping of 8 byte quantity */
 extern void ms_gswap8 (void *data8);
 
-/** In-place byte swapping of 2 byte, memory-aligned, quantity */
-extern void ms_gswap2a (void *data2);
-/** In-place byte swapping of 4 byte, memory-aligned, quantity */
-extern void ms_gswap4a (void *data4);
-/** In-place byte swapping of 8 byte, memory-aligned, quantity */
-extern void ms_gswap8a (void *data8);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5) || defined (__clang__)
+/** Deprecated: In-place byte swapping of 2 byte, memory-aligned, quantity */
+__attribute__ ((deprecated("Use ms_gswap2 instead.")))
+extern void     ms_gswap2a ( void *data2 );
+/** Deprecated: In-place byte swapping of 4 byte, memory-aligned, quantity */
+__attribute__ ((deprecated("Use ms_gswap4 instead.")))
+extern void     ms_gswap4a ( void *data4 );
+/** Deprecated: In-place byte swapping of 8 byte, memory-aligned, quantity */
+__attribute__ ((deprecated("Use ms_gswap8 instead.")))
+extern void     ms_gswap8a ( void *data8 );
+#elif defined(_MSC_FULL_VER) && (_MSC_FULL_VER > 140050320)
+/** Deprecated: In-place byte swapping of 2 byte, memory-aligned, quantity */
+__declspec(deprecated("Use ms_gswap2 instead."))
+extern void     ms_gswap2a ( void *data2 );
+/** Deprecated: In-place byte swapping of 4 byte, memory-aligned, quantity */
+__declspec(deprecated("Use ms_gswap4 instead."))
+extern void     ms_gswap4a ( void *data4 );
+/** Deprecated: In-place byte swapping of 8 byte, memory-aligned, quantity */
+__declspec(deprecated("Use ms_gswap8 instead."))
+extern void     ms_gswap8a ( void *data8 );
+#else
+/** Deprecated: In-place byte swapping of 2 byte, memory-aligned, quantity */
+extern void     ms_gswap2a ( void *data2 );
+/** Deprecated: In-place byte swapping of 4 byte, memory-aligned, quantity */
+extern void     ms_gswap4a ( void *data4 );
+/** Deprecated: In-place byte swapping of 8 byte, memory-aligned, quantity */
+extern void     ms_gswap8a ( void *data8 );
+#endif
 
 /** @} */
 

--- a/mseedformat.h
+++ b/mseedformat.h
@@ -588,7 +588,7 @@ HO2d (int16_t value, int swapflag)
 {
   if (swapflag)
   {
-    ms_gswap2a (&value);
+    ms_gswap2 (&value);
   }
   return value;
 }
@@ -597,7 +597,7 @@ HO2u (uint16_t value, int swapflag)
 {
   if (swapflag)
   {
-    ms_gswap2a (&value);
+    ms_gswap2 (&value);
   }
   return value;
 }
@@ -606,7 +606,7 @@ HO4d (int32_t value, int swapflag)
 {
   if (swapflag)
   {
-    ms_gswap4a (&value);
+    ms_gswap4 (&value);
   }
   return value;
 }
@@ -615,7 +615,7 @@ HO4u (uint32_t value, int swapflag)
 {
   if (swapflag)
   {
-    ms_gswap4a (&value);
+    ms_gswap4 (&value);
   }
   return value;
 }
@@ -624,7 +624,7 @@ HO4f (float value, int swapflag)
 {
   if (swapflag)
   {
-    ms_gswap4a (&value);
+    ms_gswap4 (&value);
   }
   return value;
 }
@@ -633,7 +633,7 @@ HO8f (double value, int swapflag)
 {
   if (swapflag)
   {
-    ms_gswap8a (&value);
+    ms_gswap8 (&value);
   }
   return value;
 }

--- a/packdata.c
+++ b/packdata.c
@@ -88,7 +88,7 @@ msr_encode_int16 (int32_t *input, int samplecount, int16_t *output,
     output[idx] = (int16_t)input[idx];
 
     if (swapflag)
-      ms_gswap2a (&output[idx]);
+      ms_gswap2 (&output[idx]);
 
     outputlength -= sizeof (int16_t);
   }
@@ -125,7 +125,7 @@ msr_encode_int32 (int32_t *input, int samplecount, int32_t *output,
     output[idx] = input[idx];
 
     if (swapflag)
-      ms_gswap4a (&output[idx]);
+      ms_gswap4 (&output[idx]);
 
     outputlength -= sizeof (int32_t);
   }
@@ -162,7 +162,7 @@ msr_encode_float32 (float *input, int samplecount, float *output,
     output[idx] = input[idx];
 
     if (swapflag)
-      ms_gswap4a (&output[idx]);
+      ms_gswap4 (&output[idx]);
 
     outputlength -= sizeof (float);
   }
@@ -199,7 +199,7 @@ msr_encode_float64 (double *input, int samplecount, double *output,
     output[idx] = input[idx];
 
     if (swapflag)
-      ms_gswap8a (&output[idx]);
+      ms_gswap8 (&output[idx]);
 
     outputlength -= sizeof (double);
   }
@@ -307,7 +307,7 @@ msr_encode_steim1 (int32_t *input, int samplecount, int32_t *output,
         ms_log (0, "Frame %d: X0=%d\n", frameidx, input[0]);
 
       if (swapflag)
-        ms_gswap4a (&frameptr[1]);
+        ms_gswap4 (&frameptr[1]);
 
       Xnp = &frameptr[2];
 
@@ -380,8 +380,8 @@ msr_encode_steim1 (int32_t *input, int samplecount, int32_t *output,
 
         if (swapflag)
         {
-          ms_gswap2a (&word->d16[0]);
-          ms_gswap2a (&word->d16[1]);
+          ms_gswap2 (&word->d16[0]);
+          ms_gswap2 (&word->d16[1]);
         }
 
         /* 2-bit nibble is 0b10 (0x2) */
@@ -398,7 +398,7 @@ msr_encode_steim1 (int32_t *input, int samplecount, int32_t *output,
         frameptr[widx] = diffs[0];
 
         if (swapflag)
-          ms_gswap4a (&frameptr[widx]);
+          ms_gswap4 (&frameptr[widx]);
 
         /* 2-bit nibble is 0b11 (0x3) */
         frameptr[0] |= 0x3ul << (30 - 2 * widx);
@@ -412,14 +412,14 @@ msr_encode_steim1 (int32_t *input, int samplecount, int32_t *output,
 
     /* Swap word with nibbles */
     if (swapflag)
-      ms_gswap4a (&frameptr[0]);
+      ms_gswap4 (&frameptr[0]);
   } /* Done with frames */
 
   /* Set Xn (reverse integration constant) in first frame to last sample */
   if (Xnp)
     *Xnp = *(input + outputsamples - 1);
   if (swapflag)
-    ms_gswap4a (Xnp);
+    ms_gswap4 (Xnp);
 
   if (byteswritten)
     *byteswritten = frameidx * 64;
@@ -502,7 +502,7 @@ msr_encode_steim2 (int32_t *input, int samplecount, int32_t *output,
         ms_log (0, "Frame %d: X0=%d\n", frameidx, input[0]);
 
       if (swapflag)
-        ms_gswap4a (&frameptr[1]);
+        ms_gswap4 (&frameptr[1]);
 
       Xnp = (int32_t *)&frameptr[2];
 
@@ -710,7 +710,7 @@ msr_encode_steim2 (int32_t *input, int samplecount, int32_t *output,
 
       /* Swap encoded word except for 4x8-bit samples */
       if (swapflag && packedsamples != 4)
-        ms_gswap4a (&frameptr[widx]);
+        ms_gswap4 (&frameptr[widx]);
 
       diffcount -= packedsamples;
       outputsamples += packedsamples;
@@ -718,14 +718,14 @@ msr_encode_steim2 (int32_t *input, int samplecount, int32_t *output,
 
     /* Swap word with nibbles */
     if (swapflag)
-      ms_gswap4a (&frameptr[0]);
+      ms_gswap4 (&frameptr[0]);
   } /* Done with frames */
 
   /* Set Xn (reverse integration constant) in first frame to last sample */
   if (Xnp)
     *Xnp = *(input + outputsamples - 1);
   if (swapflag)
-    ms_gswap4a (Xnp);
+    ms_gswap4 (Xnp);
 
   if (byteswritten)
     *byteswritten = frameidx * 64;

--- a/unpackdata.c
+++ b/unpackdata.c
@@ -64,7 +64,7 @@ msr_decode_int16 (int16_t *input, int64_t samplecount, int32_t *output,
     sample = input[idx];
 
     if (swapflag)
-      ms_gswap2a (&sample);
+      ms_gswap2 (&sample);
 
     output[idx] = (int32_t)sample;
 
@@ -100,7 +100,7 @@ msr_decode_int32 (int32_t *input, int64_t samplecount, int32_t *output,
     sample = input[idx];
 
     if (swapflag)
-      ms_gswap4a (&sample);
+      ms_gswap4 (&sample);
 
     output[idx] = sample;
 
@@ -136,7 +136,7 @@ msr_decode_float32 (float *input, int64_t samplecount, float *output,
     memcpy (&sample, &input[idx], sizeof (float));
 
     if (swapflag)
-      ms_gswap4a (&sample);
+      ms_gswap4 (&sample);
 
     output[idx] = sample;
 
@@ -172,7 +172,7 @@ msr_decode_float64 (double *input, int64_t samplecount, double *output,
     memcpy (&sample, &input[idx], sizeof (double));
 
     if (swapflag)
-      ms_gswap8a (&sample);
+      ms_gswap8 (&sample);
 
     output[idx] = sample;
 
@@ -234,8 +234,8 @@ msr_decode_steim1 (int32_t *input, int inputlength, int64_t samplecount,
     {
       if (swapflag)
       {
-        ms_gswap4a (&frame[1]);
-        ms_gswap4a (&frame[2]);
+        ms_gswap4 (&frame[1]);
+        ms_gswap4 (&frame[2]);
       }
 
       X0 = frame[1];
@@ -256,7 +256,7 @@ msr_decode_steim1 (int32_t *input, int inputlength, int64_t samplecount,
 
     /* Swap 32-bit word containing the nibbles */
     if (swapflag)
-      ms_gswap4a (&frame[0]);
+      ms_gswap4 (&frame[0]);
 
     /* Decode each 32-bit word according to nibble */
     for (widx = startnibble; widx < 16 && samplecount > 0; widx++)
@@ -287,8 +287,8 @@ msr_decode_steim1 (int32_t *input, int inputlength, int64_t samplecount,
 
         if (swapflag)
         {
-          ms_gswap2a (&word->d16[0]);
-          ms_gswap2a (&word->d16[1]);
+          ms_gswap2 (&word->d16[0]);
+          ms_gswap2 (&word->d16[1]);
         }
 
         if (libmseed_decodedebug > 0)
@@ -298,7 +298,7 @@ msr_decode_steim1 (int32_t *input, int inputlength, int64_t samplecount,
       case 3: /* 11: One 4-byte difference */
         diffcount = 1;
         if (swapflag)
-          ms_gswap4a (&word->d32);
+          ms_gswap4 (&word->d32);
 
         if (libmseed_decodedebug > 0)
           ms_log (0, "  W%02d: 11=1x32b  %d\n", widx, word->d32);
@@ -389,8 +389,8 @@ msr_decode_steim2 (int32_t *input, int inputlength, int64_t samplecount,
     {
       if (swapflag)
       {
-        ms_gswap4a (&frame[1]);
-        ms_gswap4a (&frame[2]);
+        ms_gswap4 (&frame[1]);
+        ms_gswap4 (&frame[2]);
       }
 
       X0 = frame[1];
@@ -411,7 +411,7 @@ msr_decode_steim2 (int32_t *input, int inputlength, int64_t samplecount,
 
     /* Swap 32-bit word containing the nibbles */
     if (swapflag)
-      ms_gswap4a (&frame[0]);
+      ms_gswap4 (&frame[0]);
 
     /* Decode each 32-bit word according to nibble */
     for (widx = startnibble; widx < 16 && samplecount > 0; widx++)
@@ -442,7 +442,7 @@ msr_decode_steim2 (int32_t *input, int inputlength, int64_t samplecount,
 
       case 2: /* nibble=10: Must consult dnib, the high order two bits */
         if (swapflag)
-          ms_gswap4a (&frame[widx]);
+          ms_gswap4 (&frame[widx]);
         dnib = EXTRACTBITRANGE (frame[widx], 30, 2);
 
         switch (dnib)
@@ -494,7 +494,7 @@ msr_decode_steim2 (int32_t *input, int inputlength, int64_t samplecount,
 
       case 3: /* nibble=11: Must consult dnib, the high order two bits */
         if (swapflag)
-          ms_gswap4a (&frame[widx]);
+          ms_gswap4 (&frame[widx]);
         dnib = EXTRACTBITRANGE (frame[widx], 30, 2);
 
         switch (dnib)
@@ -654,7 +654,7 @@ msr_decode_geoscope (char *input, int64_t samplecount, float *output,
     case DE_GEOSCOPE163:
       memcpy (&sint, input, sizeof (int16_t));
       if (swapflag)
-        ms_gswap2a (&sint);
+        ms_gswap2 (&sint);
 
       /* Recover mantissa and gain range factor */
       mantissa  = (sint & GEOSCOPE_MANTISSA_MASK);
@@ -671,7 +671,7 @@ msr_decode_geoscope (char *input, int64_t samplecount, float *output,
     case DE_GEOSCOPE164:
       memcpy (&sint, input, sizeof (int16_t));
       if (swapflag)
-        ms_gswap2a (&sint);
+        ms_gswap2 (&sint);
 
       /* Recover mantissa and gain range factor */
       mantissa  = (sint & GEOSCOPE_MANTISSA_MASK);
@@ -767,7 +767,7 @@ msr_decode_cdsn (int16_t *input, int64_t samplecount, int32_t *output,
   {
     memcpy (&sint, &input[idx], sizeof (int16_t));
     if (swapflag)
-      ms_gswap2a (&sint);
+      ms_gswap2 (&sint);
 
     /* Recover mantissa and gain range factor */
     mantissa  = (sint & CDSN_MANTISSA_MASK);
@@ -860,7 +860,7 @@ msr_decode_sro (int16_t *input, int64_t samplecount, int32_t *output,
   {
     memcpy (&sint, &input[idx], sizeof (int16_t));
     if (swapflag)
-      ms_gswap2a (&sint);
+      ms_gswap2 (&sint);
 
     /* Recover mantissa and gain range factor */
     mantissa  = (sint & SRO_MANTISSA_MASK);
@@ -913,7 +913,7 @@ msr_decode_dwwssn (int16_t *input, int64_t samplecount, int32_t *output,
   {
     memcpy (&sint, &input[idx], sizeof (uint16_t));
     if (swapflag)
-      ms_gswap2a (&sint);
+      ms_gswap2 (&sint);
     sample = (int32_t)sint;
 
     /* Take 2's complement for sample */


### PR DESCRIPTION
Firstly, compilers are smart enough that the naive copy-and-bit shift method is converted to a register load/store + `bswap` intrinsic. Specialized versions only serve to confuse the reader and end up with the same or worse compiled code.

Secondly, the cast to `uint32_t*` on a `float` array (in `msr_decode_float32` via `ms_gswap4a`) appears to violate strict aliasing rules, such that an optimizing compiler _ignores the byte swap entirely_.