### PR TITLE
doc: fix typo in ms_selection.3

### DIFF
--- a/doc/ms_selection.3
+++ b/doc/ms_selection.3
@@ -62,7 +62,7 @@ a selection entry to the \fIselections\fP list.  The \fInet\fP,
 are used to create a \fIsrcname\fP.  The name components may contain
 globbing characters for matching including wildcards and character
 sets, see \fBSRCNAME MATCHING\fP below.  If a name component is not
-specified a wildard matching all entries will be subsituted,
+specified a wildard matching all entries will be substituted,
 i.e. \fInet\fP==NULL will be interpreted to match all network codes.
 As a special case a \fIloc\fP value of "--" will be translated to and
 empty string to match the srcname representation of a blank


### PR DESCRIPTION
Spotted by Lintian: https://lintian.debian.org/sources/libmseed.