### PR TITLE
Fix uninitialized file position in ms3_readtracelist_selection()

### DIFF
--- a/fileutils.c
+++ b/fileutils.c
@@ -672,7 +672,7 @@ ms3_readtracelist_selection (MS3TraceList **ppmstl, const char *mspath,
   MS3RecordPtr *recordptr = NULL;
   uint32_t dataoffset;
   uint32_t datasize;
-  int64_t fpos;
+  int64_t fpos = 0;
   int retcode;
 
   if (!ppmstl)


### PR DESCRIPTION
When calling `ms3_tracelist()` (and thereafter
`ms3_tracelist_selection()`), previously the position within the
file from which records were first read was undefined, because
`fpos` was used uninitialized.  This in general did not cause
problems, but repeated calls to the library could leave `fpos`
taking an arbitrary value, including a negative one.  In that
case, when the negative, non-0 value of `fpos` was read in
`ms3_readmsr_selection()` the first time, it was taken to be a
'legacy' request to start reading records at some non-0 offset
within the file.

Fix this by initializing `fpos` in `ms3_tracelist_selection()`
to 0.

This potential error and its fix was spotted by @bakerb845.

Closes #70.
