### PR TITLE
fix: missing include sys/types.h, due to use of type `off_t`

### DIFF
--- a/libmseed.h
+++ b/libmseed.h
@@ -38,6 +38,7 @@ extern "C" {
 #include <time.h>
 #include <string.h>
 #include <ctype.h>
+#include <sys/types.h>
 
 /* This library uses structs that map to SEED header/blockette
    structures that are required to have a layout exactly as specified,


### PR DESCRIPTION
Hello,

due to use of `off_t` type, it's required to #include <sys/types.h>

Build fails at least on Debian 12.

Please consider merging.